### PR TITLE
Add support for htmlbeautifier options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ This extension basically using [htmlbeautifier](https://github.com/threedaymonk/
 gem install htmlbeautifier
 ```
 
+## Settings
+
+| Setting                              | Description                                           | Default |
+| ------------------------------------ | ----------------------------------------------------- | ------- |
+| `vscode-erb-beautify.tabStops`       | Set number of spaces per indent                       | 2       |
+| `vscode-erb-beautify.tab`            | Indent using tabs                                     | false   |
+| `vscode-erb-beautify.indentBy`       | Indent the output by NUMBER steps                     | 0       |
+| `vscode-erb-beautify.stopOnErrors`   | Stop when invalid nesting is encountered in the input | false   |
+| `vscode-erb-beautify.keepBlankLines` | Set number of consecutive blank lines                 | 0       |
+
 ## References
 
 [Issue](https://github.com/threedaymonk/htmlbeautifier/issues/49)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,38 @@
             "id": "erb",
             "aliases": ["ERB"],
             "extensions": [".erb"]
-        }]
+        }],
+        "configuration": {
+            "type": "object",
+            "title": "VSCode ERB Beautify configuration",
+            "properties": {
+                "vscode-erb-beautify.tabStops": {
+                    "type": "number",
+                    "default": 2,
+                    "description": "Set number of spaces per indent (default 2)"
+                },
+                "vscode-erb-beautify.tab": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indent using tabs"
+                },
+                "vscode-erb-beautify.indentBy": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Indent the output by NUMBER steps (default 0)"
+                },
+                "vscode-erb-beautify.stopOnErrors": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Stop when invalid nesting is encountered in the input"
+                },
+                "vscode-erb-beautify.keepBlankLines": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Set number of consecutive blank lines"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Resolves #1

- Uses the same option names and defaults as htmlbeautifier.
- Removes empty tmp file left behind by htmlbeautifier if
  invalid nesting is encountered and stopOnErrors is set to true.