### PR TITLE
add ext to cp.spawn command for win32

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,8 @@ export function activate(context: vscode.ExtensionContext) {
     provideDocumentFormattingEdits(
       document: vscode.TextDocument
     ): vscode.TextEdit[] {
-      const beautifier = cp.spawn("htmlbeautifier", ["-v"]);
+      const ext = process.platform === "win32" ? ".bat" : "";
+      const beautifier = cp.spawn(`htmlbeautifier${ext}`, ["-v"]);
 
       beautifier.on("error", err => {
         if (err.message.includes("ENOENT")) {


### PR DESCRIPTION
Added '.bat' extension to cp.spawn command parameter if platform is windows.