### PR TITLE
Speed up formatting

### DIFF
--- a/src/formatter/htmlbeautifier.ts
+++ b/src/formatter/htmlbeautifier.ts
@@ -9,6 +9,13 @@ export default class HtmlBeautifier {
   constructor() {
     this.logger = vscode.window.createOutputChannel("ERB Formatter/Beautify");
     this.htmlbeautifier = this.initializeBeautifier();
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      const isAffected = event.affectsConfiguration("vscode-erb-beautify");
+      if (!isAffected) {
+        return;
+      }
+      this.htmlbeautifier = this.initializeBeautifier();
+    });
   }
 
   /**

--- a/src/formatter/htmlbeautifier.ts
+++ b/src/formatter/htmlbeautifier.ts
@@ -14,6 +14,7 @@ export default class HtmlBeautifier {
       if (!isAffected) {
         return;
       }
+      this.htmlbeautifier.kill();
       this.htmlbeautifier = this.initializeBeautifier();
     });
   }

--- a/src/formatter/htmlbeautifier.ts
+++ b/src/formatter/htmlbeautifier.ts
@@ -24,6 +24,18 @@ export default class HtmlBeautifier {
    * @returns {Promise<string>} The formatted data
    */
   public async format(data: string): Promise<string> {
+    if (
+      this.htmlbeautifier === null ||
+      this.htmlbeautifier.stdin === null ||
+      this.htmlbeautifier.stdout === null
+    ) {
+      const msg =
+        "Couldn't initialize htmlbeautifier. Make sure the gem is installed and available in PATH.";
+      console.error(msg);
+      vscode.window.showErrorMessage(msg);
+      throw new Error(msg);
+    }
+
     try {
       const cmd = `${this.exe} ${this.cliOptions.join(
         " "


### PR DESCRIPTION
Thanks for the great extension!

I noticed that the formatting is quite slow and it's not practical to wait 3-5 seconds for the formatting to complete.
I figured out that the majority of the time is spent on the start of htmlbeautifier command.
The actual formatting is quite fast, after the booting is done.

In order to speed up the formatting, I modified the extension so that it always has an htmlbeautifier process started and waiting for input.
When the `format` is called, the running htmlbeautifier process is passed the input and, after the output is returned and process exits, a new htmlbeautifier process is started.