### PR TITLE
Enable formatter in html erb

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,17 @@ import HtmlBeautifierProvider from "./formatter/htmlbeautifierProvider";
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.languages.registerDocumentFormattingEditProvider(
-      "erb",
+      {
+        language: "erb",
+        pattern: "**/*.html.erb",
+      },
       new HtmlBeautifierProvider()
     ),
     vscode.languages.registerDocumentRangeFormattingEditProvider(
-      "erb",
+      {
+        language: "erb",
+        pattern: "**/*.html.erb",
+      },
       new HtmlBeautifierProvider()
     )
   );


### PR DESCRIPTION
Ensured that the formatter is only active for `.html.erb` files. 
Extending the formatter to apply universally to ERB files caused unnecessary formatting when saving files like `email.text.erb`.
Now, the formatter will strictly format `.html.erb` files, preventing unwanted formatting in other ERB file types.